### PR TITLE
Print metadata on start

### DIFF
--- a/include/yampplayer.h
+++ b/include/yampplayer.h
@@ -30,6 +30,8 @@ namespace YAMP
 
         std::string getMetadata(std::string key);
         double getDuration();
+
+        int getNumOf(std::string key);
     };
 };
 

--- a/include/yampplayer.h
+++ b/include/yampplayer.h
@@ -28,7 +28,8 @@ namespace YAMP
         bool hasFinished();
         void setHasFinished(bool hasFinished);
 
-        std::string getMetadata(std::string& key);
+        std::string getMetadata(std::string key);
+        double getDuration();
     };
 };
 

--- a/include/yampplayer.h
+++ b/include/yampplayer.h
@@ -27,6 +27,8 @@ namespace YAMP
 
         bool hasFinished();
         void setHasFinished(bool hasFinished);
+
+        std::string getMetadata(std::string& key);
     };
 };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,6 +4,7 @@
 #include <fstream>
 #include <iomanip>
 #include <iostream>
+#include <filesystem>
 
 int main(int argc, char* argv[])
 {
@@ -22,6 +23,27 @@ int main(int argc, char* argv[])
 	try
 	{
 		YAMP::YAMPPlayer yamp(file, options);
+
+		// Print some info
+		std::cout << "Filename........: " <<
+			std::filesystem::path(args.file).filename().string() << std::endl;
+		std::cout << "Title...........: " <<
+			yamp.getMetadata("title") << std::endl;
+		std::cout << "Artist..........: " <<
+			yamp.getMetadata("artist") << std::endl;
+		std::cout << "Type............: " <<
+			yamp.getMetadata("type_long") << std::endl;
+		std::cout << "Duration........: " <<
+			yamp.getDuration() << std::endl;
+		std::cout << "# of Channels...: " <<
+			yamp.getNumOf("channels") << std::endl;
+		std::cout << "# of Instruments: " <<
+			yamp.getNumOf("instruments") << std::endl;
+		std::cout << "# of Patterns...: " <<
+			yamp.getNumOf("patterns") << std::endl;
+		std::cout << "# of Samples....: " <<
+			yamp.getNumOf("samples") << std::endl;
+
 		yamp.play();
 
 		while (true) 

--- a/src/yampplayer.cpp
+++ b/src/yampplayer.cpp
@@ -92,3 +92,15 @@ double YAMP::YAMPPlayer::getDuration()
 {
     return m_module.get_duration_seconds();
 }
+
+int YAMP::YAMPPlayer::getNumOf(std::string key)
+{
+    if (key == "channels") return m_module.get_num_channels();
+    if (key == "instruments") return m_module.get_num_instruments();
+    if (key == "orders") return m_module.get_num_orders();
+    if (key == "patterns") return m_module.get_num_patterns();
+    if (key == "samples") return m_module.get_num_samples();
+    if (key == "subsongs") return m_module.get_num_subsongs();
+
+    return 0;
+}

--- a/src/yampplayer.cpp
+++ b/src/yampplayer.cpp
@@ -83,7 +83,12 @@ void YAMP::YAMPPlayer::setHasFinished(bool hasFinished)
     m_hasFinished = hasFinished;
 }
 
-std::string getMetadata(std::string& key)
+std::string YAMP::YAMPPlayer::getMetadata(std::string key)
 {
     return m_module.get_metadata(key);
+}
+
+double YAMP::YAMPPlayer::getDuration()
+{
+    return m_module.get_duration_seconds();
 }

--- a/src/yampplayer.cpp
+++ b/src/yampplayer.cpp
@@ -82,3 +82,8 @@ void YAMP::YAMPPlayer::setHasFinished(bool hasFinished)
 {
     m_hasFinished = hasFinished;
 }
+
+std::string getMetadata(std::string& key)
+{
+    return m_module.get_metadata(key);
+}


### PR DESCRIPTION
Print some info at the start of playback like old YAMP did.

fixes #6 